### PR TITLE
Add public static to function

### DIFF
--- a/root/includes/hooks/hook_oauthorize.php
+++ b/root/includes/hooks/hook_oauthorize.php
@@ -13,7 +13,7 @@ class OauthLogin
 {
   // Loading on each page
   
-  function before_template_display(&$hook, $handle, $include_once = true)
+  public static function before_template_display(&$hook, $handle, $include_once = true)
 	{
      global $template, $user, $phpbb_root_path, $phpEx, $config, $mode;
      if($mode == 'logout')


### PR DESCRIPTION
Should fix 

```
PHP Strict Standards:  call_user_func_array() expects parameter 1 to be a valid callback, non-static method OauthLogin::before_template_display() should not be called statically in /www/forum.iiet.pl/public_html/includes/hooks/index.php on line 141
```
